### PR TITLE
Fix throwing exeptions on WeMos boards

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -20,7 +20,7 @@ void runString(String str) {
     run.start();
 
     while (run.tick() != RG_FINISH) {
-        delay(5);
+        delay(1);
         yield();
     }
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -20,7 +20,7 @@ void runString(String str) {
     run.start();
 
     while (run.tick() != RG_FINISH) {
-        delay(0);
+        delay(5);
         yield();
     }
 }


### PR DESCRIPTION
На некоторых реализациях wemos D1 Mini с ESP8266 текущий код падает через ~2c со стектрейсом и плата перезагружается.  Стектрейс всегда сорержит реализацию delay для ESP, причем стектрейс всегда разный, например:
```
0x40225a29 in esp_try_delay(unsigned int, unsigned int, unsigned int) at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp:169
0x4022a66c in Print::write(unsigned char const*, unsigned int) at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Print.cpp:35
0x4020a478 in BallMatrix::update() at src/matrix_strip.cpp:22
0x402071dd in RunningGFX::tickManual(bool) at lib\GyverGFX-dev\src/RunningGFX.h:119
0x40226260 in esp_delay<__delay(long unsigned int)::<lambda()> > at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/coredecls.h:69     
 (inlined by) esp_delay<__delay(long unsigned int)::<lambda()> > at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/coredecls.h:78     
 (inlined by) __delay at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_wiring.cpp:39
0x402079f4 in runString(String) at src/main.cpp:24
0x40276da8 in system_get_sdk_version at ??:?
0x402241f2 in String::operator=(String const&) at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/WString.cpp:305
0x40207a5a in String::~String() at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/WString.h:115
 (inlined by) operator() at src/main.cpp:50
 (inlined by) __invoke_impl<void, setup()::<lambda()>&> at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/invoke.h:60    
 (inlined by) __invoke_r<void, setup()::<lambda()>&> at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/invoke.h:110      
 (inlined by) _M_invoke at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/std_function.h:291
0x401000e5 in std::function<void ()>::operator()() const at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/std_function.h:623
0x40218431 in String::~String() at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/WString.h:115
 (inlined by) operator() at src/settings.cpp:103
0x40100db9 in malloc at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266\umm_malloc/umm_malloc.cpp:912
0x4022aa0c in precache at ??:?
0x40209608 in GyverDB::setHook(void*, unsigned int, gdb::AnyType&) at .pio\libdeps\d1_mini\GyverDB\src/GyverDB.h:279
0x4022aa0c in precache at ??:?
0x40209608 in GyverDB::setHook(void*, unsigned int, gdb::AnyType&) at .pio\libdeps\d1_mini\GyverDB\src/GyverDB.h:279
0x40207b41 in std::enable_if<std::__and_<std::__not_<std::__is_tuple_like<std::_Any_data> >, std::is_move_constructible<std::_Any_data>, std::is_move_assignable<std::_Any_data> >::value, void>::type std::swap<std::_Any_data>(std::_Any_data&, std::_Any_data&) at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/move.h:197
 (inlined by) std::function<void ()>::swap(std::function<void ()>&) at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/std_function.h:483
 (inlined by) std::function<void ()>::operator=(std::function<void ()> const&) at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/std_function.h:398
 (inlined by) WiFiConnectorClass::onError(std::function<void ()>) at .pio\libdeps\d1_mini\WiFiConnector\src/WiFiConnector.h:50
 (inlined by) setup at src/main.cpp:46
0x40218690 in std::_Function_handler<void (), __loop_obj_178::{lambda()#1}>::_M_invoke(std::_Any_data const&) at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/std_function.h:293
0x401000e5 in std::function<void ()>::operator()() const at c:\users\loginov\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\10.3.0\bits/std_function.h:623
0x4021ffcd in LoopTask::exec() at .pio\libdeps\d1_mini\Looper\src\nodes/LoopTask.cpp:14
0x4021fee5 in LooperClass::loop() at .pio\libdeps\d1_mini\Looper\src/LooperClass.cpp:22
0x40207a7c in loop at src/main.cpp:56
0x40225916 in loop_wrapper() at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp:258
0x40101185 in cont_wrapper at C:\Users\Loginov\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/cont.S:81
```

По нему лично мне было непонятно, в чем ошибка. Спустя день экспериментов нашел, что проблема где-то в реализации RunningGFX т.к. выпиливая её всё работает нормально.  В первопричине не разобрался, но указывая delay > 0, либо вместо `run.tick` используя `run.tickManual` ошибки пропадают, плата начинает работать стабильно.